### PR TITLE
Update to TypeScript 5

### DIFF
--- a/.changeset/typescript-5.md
+++ b/.changeset/typescript-5.md
@@ -1,0 +1,5 @@
+---
+vscode-mdx: minor
+---
+
+Update to TypeScript 5.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "remark-cli": "^11.0.0",
     "remark-frontmatter": "^4.0.0",
     "remark-preset-wooorm": "^9.0.0",
-    "typescript": "^4.0.0",
+    "typescript": "^5.0.0",
     "xo": "^0.53.0"
   },
   "prettier": {

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@mdx-js/language-service": "0.0.0",
     "load-plugin": "^5.0.0",
+    "typescript": "^5.0.0",
     "vscode-languageserver": "^8.0.0",
     "vscode-languageserver-textdocument": "^1.0.0"
   },

--- a/packages/language-service/lib/index.js
+++ b/packages/language-service/lib/index.js
@@ -862,6 +862,7 @@ export function createMdxLanguageService(ts, host, plugins) {
     provideInlayHints: notImplemented('provideInlayHints'),
     toggleLineComment: notImplemented('toggleLineComment'),
     toggleMultilineComment: notImplemented('toggleMultilineComment'),
+    getSupportedCodeFixes: notImplemented('getSupportedCodeFixes'),
     uncommentSelection: notImplemented('uncommentSelection')
   }
 


### PR DESCRIPTION
Also the missing `typescript` dependency was added to `@mdx-js/language-server`.