### PR TITLE
Pin @types/unist to version 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "typescript": "^5.0.0",
     "xo": "^0.54.0"
   },
+  "overrides": {
+    "@types/unist": "^2.0.0"
+  },
   "prettier": {
     "tabWidth": 2,
     "useTabs": false,


### PR DESCRIPTION
`@types/hast` depends on `@types/unist@*`. This causes TypeScript compatibility issues.