### PR TITLE
Define the gallery banner color

### DIFF
--- a/packages/vscode-mdx/package.json
+++ b/packages/vscode-mdx/package.json
@@ -55,6 +55,10 @@
     "undici": "^5.0.0",
     "vscode-languageclient": "^8.0.0"
   },
+  "galleryBanner": {
+    "color": "#fcb32c",
+    "theme": "light"
+  },
   "contributes": {
     "configuration": [
       {


### PR DESCRIPTION
This changes the color of the banner on https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-mdx, so it stands out a bit more.

Default:

![image](https://github.com/mdx-js/mdx-analyzer/assets/779047/9f644a18-6fc5-4dd9-8612-81ae565ef792)


With this change:

![image](https://github.com/mdx-js/mdx-analyzer/assets/779047/8ac4baa5-7795-45dd-93b8-5fd148822eba)
