### PR TITLE
Use JavaScript build script

### DIFF
--- a/packages/vscode-mdx/package.json
+++ b/packages/vscode-mdx/package.json
@@ -39,11 +39,11 @@
     "dependencies": false
   },
   "scripts": {
-    "build": "esbuild extension=./src/extension.js language-server=@mdx-js/language-server --bundle --platform=node --target=node16 --external:vscode --outdir=out",
-    "build:debug": "npm run copy-libs && npm run build -- --sourcemap",
+    "build": "node ./script/build.mjs",
+    "build:debug": "npm run copy-libs && npm run build debug",
     "copy-libs": "cpy '../../node_modules/typescript/lib/lib.*.d.ts' out/",
     "generate": "node --conditions development ./script/generate.mjs",
-    "vscode:prepublish": "npm run copy-libs && npm run build -- --minify"
+    "vscode:prepublish": "npm run copy-libs && npm run build"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/vscode-mdx/script/build.mjs
+++ b/packages/vscode-mdx/script/build.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import {createRequire} from 'node:module'
+import process from 'node:process'
+import {fileURLToPath} from 'node:url'
+import {build} from 'esbuild'
+
+const require = createRequire(import.meta.url)
+
+const debug = process.argv.includes('debug')
+
+await build({
+  bundle: true,
+  entryPoints: {
+    extension: require.resolve('../src/extension.js'),
+    'language-server': require.resolve('@mdx-js/language-server')
+  },
+  external: ['vscode'],
+  logLevel: 'info',
+  minify: !debug,
+  outdir: fileURLToPath(new URL('../out/', import.meta.url)),
+  platform: 'node',
+  sourcemap: debug,
+  target: 'node16',
+  plugins: [
+    {
+      name: 'alias',
+      setup({onResolve, resolve}) {
+        onResolve(
+          {filter: /^(vscode-.*|jsonc-parser)$/},
+          ({path, ...options}) =>
+            resolve(require.resolve(path).replace(/\/umd\//, '/esm/'), options)
+        )
+        onResolve({filter: /\/umd\//}, ({path, ...options}) =>
+          resolve(path.replace(/\/umd\//, '/esm/'), options)
+        )
+      }
+    }
+  ]
+})


### PR DESCRIPTION
VSCode related packages are improperly dual published. By resolving to ESM instead of CJS, we can slightly reduce bundle size.

More importantly, the upcoming transition to Volar will add additional features, some of which rely on dependencies that don’t even work without a custom ESBuild plugin.

I’m pushing this change ahead of the transition to Volar, to reduce the diffs in that upcoming PR.