### PR TITLE
Document LSP tracing configuration options

### DIFF
--- a/.changeset/chatty-houses-act.md
+++ b/.changeset/chatty-houses-act.md
@@ -1,0 +1,5 @@
+---
+'vscode-mdx': patch
+---
+
+Define the configuration options `mdx.trace.server.verbosity` and `mdx.trace.server.format`.

--- a/fixtures/fixtures.code-workspace
+++ b/fixtures/fixtures.code-workspace
@@ -1,7 +1,9 @@
 {
   "settings": {
     "git.openRepositoryInParentFolders": "never",
-    "mdx.experimentalLanguageServer": true
+    "mdx.experimentalLanguageServer": true,
+    "mdx.trace.server.verbosity": "compact",
+    "mdx.trace.server.format": "text"
   },
   "folders": [
     {"path": "demo"},

--- a/packages/vscode-mdx/package.json
+++ b/packages/vscode-mdx/package.json
@@ -68,6 +68,24 @@
             "type": "boolean",
             "default": false,
             "description": "Enable experimental IntelliSense support for MDX files."
+          },
+          "mdx.trace.server.verbosity": {
+            "enum": [
+              "off",
+              "messages",
+              "compact",
+              "verbose"
+            ],
+            "default": "off",
+            "description": "Trace MDX language server requests in the output console."
+          },
+          "mdx.trace.server.format": {
+            "enum": [
+              "text",
+              "json"
+            ],
+            "default": "text",
+            "description": "How to format traced MDX language server requests."
           }
         }
       }


### PR DESCRIPTION
This is provided by `vscode-languageserver` by default. This change just documents the configuration options and enables logging when using the fixtures workspace.