### PR TITLE
Handle dragging uri-list into MDX files

### DIFF
--- a/packages/vscode-mdx/src/document-drop-edit-provider.js
+++ b/packages/vscode-mdx/src/document-drop-edit-provider.js
@@ -75,6 +75,10 @@ export const documentDropEditProvider = {
       const content = []
 
       for (const line of uris) {
+        if (!URL.canParse(line)) {
+          continue
+        }
+
         const uri = Uri.parse(line)
         const value =
           uri.scheme === document.uri.scheme


### PR DESCRIPTION
A mime type of `uri-list` is for example files dragged from the VSCode tree view.

Images are turnes into Markdown images. These are detected based on a hardcoded list of file extensions. Other URIs are inserted as-is.

If the dragged URI uses the same scheme as the document it was dragged in, a relative path is inserted. Otherwise the full URI is used.

Closes #322
