### PR TITLE
fix: Push diagnostics from server

### DIFF
--- a/packages/vscode-mdx/src/extension.js
+++ b/packages/vscode-mdx/src/extension.js
@@ -41,8 +41,7 @@ export async function activate(context) {
     {
       documentSelector: [{language: 'mdx'}],
       initializationOptions: {
-        typescript: {tsdk},
-        diagnosticModel: DiagnosticModel.Pull
+        typescript: {tsdk}
       }
     }
   )

--- a/packages/vscode-mdx/src/extension.js
+++ b/packages/vscode-mdx/src/extension.js
@@ -3,7 +3,6 @@
  * @typedef {import('vscode').ExtensionContext} ExtensionContext
  */
 
-import {DiagnosticModel} from '@volar/language-server'
 import * as languageServerProtocol from '@volar/language-server/protocol.js'
 import {activateAutoInsertion, getTsdk, supportLabsVersion} from '@volar/vscode'
 import {languages, workspace} from 'vscode'


### PR DESCRIPTION
As an example, volarjs/starter enables client pull diagnostics by default, which causes vscode to send a diagnostic request to the server when the current file changes, which is invalid for project-aware diagnostics. Specifically, vscode does not re-request .mdx diagnostics when a .ts file is changed that affects the .mdx type.

Remove `diagnosticModel: DiagnosticModel.Pull` to solve the problem, since the default behavior is server push instead of client pull.