### PR TITLE
Syntax highlight MDX code blocks in markdown files

### DIFF
--- a/.changeset/tender-rice-notice.md
+++ b/.changeset/tender-rice-notice.md
@@ -1,0 +1,5 @@
+---
+'vscode-mdx': minor
+---
+
+Syntax highlight MDX code blocks in markdown files.

--- a/packages/vscode-mdx/package.json
+++ b/packages/vscode-mdx/package.json
@@ -160,6 +160,16 @@
           "meta.embedded.xml": "xml",
           "meta.embedded.yaml": "yaml"
         }
+      },
+      {
+        "scopeName": "source.markdown.mdx.codeblock",
+        "path": "./syntaxes/mdx.markdown.tmLanguage.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.mdx": "mdx"
+        }
       }
     ]
   }

--- a/packages/vscode-mdx/syntaxes/mdx.markdown.tmLanguage.json
+++ b/packages/vscode-mdx/syntaxes/mdx.markdown.tmLanguage.json
@@ -1,0 +1,45 @@
+{
+  "fileTypes": [],
+  "injectionSelector": "L:text.html.markdown",
+  "patterns": [
+    {
+      "include": "#mdxCodeBlock"
+    }
+  ],
+  "repository": {
+    "mdxCodeBlock": {
+      "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(mdx)(\\s+[^`~]*)?$)",
+      "name": "markup.fenced_code.block.markdown",
+      "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+      "beginCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        },
+        "4": {
+          "name": "fenced_code.block.language.markdown"
+        },
+        "5": {
+          "name": "fenced_code.block.language.attributes.markdown"
+        }
+      },
+      "endCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        }
+      },
+      "patterns": [
+        {
+          "begin": "(^|\\G)(\\s*)(.*)",
+          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "contentName": "meta.embedded.block.mdx",
+          "patterns": [
+            {
+              "include": "source.mdx"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "scopeName": "source.markdown.mdx.codeblock"
+}


### PR DESCRIPTION
This is based on https://github.com/tamasfe/taplo.