### PR TITLE
Fix dropping local media in an MDX file

### DIFF
--- a/.changeset/fix-drop-provider.md
+++ b/.changeset/fix-drop-provider.md
@@ -1,0 +1,5 @@
+---
+'volar-mdx': patch
+---
+
+Fix dropping local images in an MDX file.

--- a/packages/vscode-mdx/src/document-drop-edit-provider.js
+++ b/packages/vscode-mdx/src/document-drop-edit-provider.js
@@ -75,23 +75,23 @@ export const documentDropEditProvider = {
       const content = []
 
       for (const line of uris) {
-        if (!URL.canParse(line)) {
+        try {
+          const uri = Uri.parse(line, true)
+          const value =
+            uri.scheme === document.uri.scheme
+              ? path.posix.relative(document.uri.path, uri.path)
+              : line
+
+          content.push(
+            toMarkdown(
+              imageExtensions.has(path.posix.extname(uri.path))
+                ? {type: 'image', url: value}
+                : {type: 'text', value}
+            ).trim()
+          )
+        } catch {
           continue
         }
-
-        const uri = Uri.parse(line)
-        const value =
-          uri.scheme === document.uri.scheme
-            ? path.posix.relative(document.uri.path, uri.path)
-            : line
-
-        content.push(
-          toMarkdown(
-            imageExtensions.has(path.posix.extname(uri.path))
-              ? {type: 'image', url: value}
-              : {type: 'text', value}
-          ).trim()
-        )
       }
 
       return {


### PR DESCRIPTION
This was using `URL.canParse`, which isn’t available in the Node.js version used by VSCode. This failed silently. This is fixed by using strict parse mode from `vscode-uri`.

Closes #322
