### PR TITLE
Remove the language module dependency on TypeScript

### DIFF
--- a/.changeset/purple-kings-unite.md
+++ b/.changeset/purple-kings-unite.md
@@ -1,0 +1,5 @@
+---
+"@mdx-js/language-service": minor
+---
+
+Remove the dependency on an injected TypeScript module instance.

--- a/packages/language-server/lib/language-server-plugin.js
+++ b/packages/language-server/lib/language-server-plugin.js
@@ -40,7 +40,7 @@ export function plugin({modules}) {
       )
 
       config.languages ||= {}
-      config.languages.mdx ||= getLanguageModule(modules.typescript, plugins)
+      config.languages.mdx ||= getLanguageModule(plugins)
 
       config.services ||= {}
       config.services.markdown = createMarkdownService()

--- a/packages/language-service/lib/language-module.js
+++ b/packages/language-service/lib/language-module.js
@@ -19,6 +19,44 @@ import remarkParse from 'remark-parse'
 import {unified} from 'unified'
 
 /**
+ * A TypeScript compatible script snapshot that wraps a string of text.
+ *
+ * @implements {IScriptSnapshot}
+ */
+export class ScriptSnapshot {
+  /**
+   * @param {string} text
+   *   The text to wrap.
+   */
+  constructor(text) {
+    this.text = text
+  }
+
+  /**
+   * Not implemented.
+   *
+   * @returns {undefined}
+   */
+  getChangeRange() {}
+
+  /**
+   * @returns {number}
+   */
+  getLength() {
+    return this.text.length
+  }
+
+  /**
+   * @param {number} start
+   * @param {number} end
+   * @returns {string}
+   */
+  getText(start, end) {
+    return this.text.slice(start, end)
+  }
+}
+
+/**
  * @param {string} propsName
  */
 const layoutJsDoc = (propsName) => `
@@ -213,11 +251,10 @@ function processExports(mdx, node, mapping, esm) {
 /**
  * @param {string} fileName
  * @param {IScriptSnapshot} snapshot
- * @param {typeof import('typescript')} ts
  * @param {Processor} processor
  * @returns {VirtualFile[]}
  */
-function getVirtualFiles(fileName, snapshot, ts, processor) {
+function getVirtualFiles(fileName, snapshot, processor) {
   const mdx = snapshot.getText(0, snapshot.getLength())
   /** @type {Mapping[]} */
   const jsMappings = []
@@ -233,17 +270,17 @@ function getVirtualFiles(fileName, snapshot, ts, processor) {
         fileName: fileName + '.jsx',
         languageId: 'javascriptreact',
         typescript: {
-          scriptKind: ts.ScriptKind.JSX
+          scriptKind: 2
         },
         mappings: jsMappings,
-        snapshot: ts.ScriptSnapshot.fromString(fallback)
+        snapshot: new ScriptSnapshot(fallback)
       },
       {
         embeddedFiles: [],
         fileName: fileName + '.md',
         languageId: 'markdown',
         mappings: [],
-        snapshot: ts.ScriptSnapshot.fromString(mdx)
+        snapshot: new ScriptSnapshot(mdx)
       }
     ]
   }
@@ -385,7 +422,7 @@ function getVirtualFiles(fileName, snapshot, ts, processor) {
                 }
               }
             ],
-            snapshot: ts.ScriptSnapshot.fromString(node.value)
+            snapshot: new ScriptSnapshot(node.value)
           })
 
           break
@@ -493,17 +530,17 @@ function getVirtualFiles(fileName, snapshot, ts, processor) {
       fileName: fileName + '.jsx',
       languageId: 'javascriptreact',
       typescript: {
-        scriptKind: ts.ScriptKind.JSX
+        scriptKind: 2
       },
       mappings: jsMappings,
-      snapshot: ts.ScriptSnapshot.fromString(esm)
+      snapshot: new ScriptSnapshot(esm)
     },
     {
       embeddedFiles: [],
       fileName: fileName + '.md',
       languageId: 'markdown',
       mappings: [markdownMapping],
-      snapshot: ts.ScriptSnapshot.fromString(markdown)
+      snapshot: new ScriptSnapshot(markdown)
     }
   )
 
@@ -513,15 +550,13 @@ function getVirtualFiles(fileName, snapshot, ts, processor) {
 /**
  * Create a [Volar](https://volarjs.dev) language module to support MDX.
  *
- * @param {typeof import('typescript')} ts
- *   The TypeScript module.
  * @param {PluggableList} [plugins]
  *   A list of remark syntax plugins. Only syntax plugins are supported.
  *   Transformers are unused.
  * @returns {LanguagePlugin}
  *   A Volar language module to support MDX.
  */
-export function getLanguageModule(ts, plugins) {
+export function getLanguageModule(plugins) {
   const processor = unified().use(remarkParse).use(remarkMdx)
   if (plugins) {
     processor.use(plugins)
@@ -538,7 +573,7 @@ export function getLanguageModule(ts, plugins) {
       const length = snapshot.getLength()
 
       return {
-        embeddedFiles: getVirtualFiles(fileName, snapshot, ts, processor),
+        embeddedFiles: getVirtualFiles(fileName, snapshot, processor),
         fileName,
         languageId: 'mdx',
         mappings: [
@@ -583,7 +618,6 @@ export function getLanguageModule(ts, plugins) {
       mdxFile.embeddedFiles = getVirtualFiles(
         mdxFile.fileName,
         snapshot,
-        ts,
         processor
       )
     },
@@ -600,7 +634,7 @@ export function getLanguageModule(ts, plugins) {
           ...host,
           getCompilationSettings: () => ({
             // Default to the JSX automatic runtime, because that’s what MDX does.
-            jsx: ts.JsxEmit.ReactJSX,
+            jsx: 4,
             // Set these defaults to match MDX if the user explicitly sets the classic runtime.
             jsxFactory: 'React.createElement',
             jsxFragmentFactory: 'React.Fragment',

--- a/packages/language-service/test/language-module.js
+++ b/packages/language-service/test/language-module.js
@@ -7,9 +7,10 @@ import {test} from 'node:test'
 import remarkFrontmatter from 'remark-frontmatter'
 import typescript from 'typescript'
 import {getLanguageModule} from '@mdx-js/language-service'
+import {ScriptSnapshot} from '../lib/language-module.js'
 
 test('create virtual file w/ mdxjsEsm', () => {
-  const module = getLanguageModule(typescript)
+  const module = getLanguageModule()
 
   const snapshot = snapshotFromLines('import {Planet} from "./Planet.js"', '')
 
@@ -40,7 +41,7 @@ test('create virtual file w/ mdxjsEsm', () => {
         fileName: '/test.mdx.jsx',
         languageId: 'javascriptreact',
         typescript: {
-          scriptKind: 2
+          scriptKind: typescript.ScriptKind.JSX
         },
         mappings: [
           {
@@ -101,7 +102,7 @@ test('create virtual file w/ mdxjsEsm', () => {
 })
 
 test('create virtual file w/o MDX layout in case of named re-export', () => {
-  const module = getLanguageModule(typescript)
+  const module = getLanguageModule()
 
   const snapshot = snapshotFromLines('export {named} from "./Layout.js"', '')
 
@@ -132,7 +133,7 @@ test('create virtual file w/o MDX layout in case of named re-export', () => {
         fileName: '/test.mdx.jsx',
         languageId: 'javascriptreact',
         typescript: {
-          scriptKind: 2
+          scriptKind: typescript.ScriptKind.JSX
         },
         mappings: [
           {
@@ -193,7 +194,7 @@ test('create virtual file w/o MDX layout in case of named re-export', () => {
 })
 
 test('create virtual file w/ MDX layout in case of default re-export', () => {
-  const module = getLanguageModule(typescript)
+  const module = getLanguageModule()
 
   const snapshot = snapshotFromLines('export {default} from "./Layout.js"', '')
 
@@ -224,7 +225,7 @@ test('create virtual file w/ MDX layout in case of default re-export', () => {
         fileName: '/test.mdx.jsx',
         languageId: 'javascriptreact',
         typescript: {
-          scriptKind: 2
+          scriptKind: typescript.ScriptKind.JSX
         },
         mappings: [
           {
@@ -285,7 +286,7 @@ test('create virtual file w/ MDX layout in case of default re-export', () => {
 })
 
 test('create virtual file w/ MDX layout in case of named and default re-export', () => {
-  const module = getLanguageModule(typescript)
+  const module = getLanguageModule()
 
   const snapshot = snapshotFromLines(
     'export {named, default} from "./Layout.js"',
@@ -319,7 +320,7 @@ test('create virtual file w/ MDX layout in case of named and default re-export',
         fileName: '/test.mdx.jsx',
         languageId: 'javascriptreact',
         typescript: {
-          scriptKind: 2
+          scriptKind: typescript.ScriptKind.JSX
         },
         mappings: [
           {
@@ -380,7 +381,7 @@ test('create virtual file w/ MDX layout in case of named and default re-export',
 })
 
 test('create virtual file w/ MDX layout in case of default and named re-export', () => {
-  const module = getLanguageModule(typescript)
+  const module = getLanguageModule()
 
   const snapshot = snapshotFromLines(
     'export {default, named} from "./Layout.js"',
@@ -414,7 +415,7 @@ test('create virtual file w/ MDX layout in case of default and named re-export',
         fileName: '/test.mdx.jsx',
         languageId: 'javascriptreact',
         typescript: {
-          scriptKind: 2
+          scriptKind: typescript.ScriptKind.JSX
         },
         mappings: [
           {
@@ -475,7 +476,7 @@ test('create virtual file w/ MDX layout in case of default and named re-export',
 })
 
 test('create virtual file w/ MDX layout in case of a default exported arrow function', () => {
-  const module = getLanguageModule(typescript)
+  const module = getLanguageModule()
 
   const snapshot = snapshotFromLines('export default () => {}', '')
 
@@ -506,7 +507,7 @@ test('create virtual file w/ MDX layout in case of a default exported arrow func
         fileName: '/test.mdx.jsx',
         languageId: 'javascriptreact',
         typescript: {
-          scriptKind: 2
+          scriptKind: typescript.ScriptKind.JSX
         },
         mappings: [
           {
@@ -581,7 +582,7 @@ test('create virtual file w/ MDX layout in case of a default exported arrow func
 })
 
 test('create virtual file w/ MDX layout in case of a default exported function declaration', () => {
-  const module = getLanguageModule(typescript)
+  const module = getLanguageModule()
 
   const snapshot = snapshotFromLines(
     'export default function MDXLayout() {}',
@@ -615,7 +616,7 @@ test('create virtual file w/ MDX layout in case of a default exported function d
         fileName: '/test.mdx.jsx',
         languageId: 'javascriptreact',
         typescript: {
-          scriptKind: 2
+          scriptKind: typescript.ScriptKind.JSX
         },
         mappings: [
           {
@@ -690,7 +691,7 @@ test('create virtual file w/ MDX layout in case of a default exported function d
 })
 
 test('create virtual file w/ MDX layout in case of a default exported constant', () => {
-  const module = getLanguageModule(typescript)
+  const module = getLanguageModule()
 
   const snapshot = snapshotFromLines('export default "main"', '')
 
@@ -721,7 +722,7 @@ test('create virtual file w/ MDX layout in case of a default exported constant',
         fileName: '/test.mdx.jsx',
         languageId: 'javascriptreact',
         typescript: {
-          scriptKind: 2
+          scriptKind: typescript.ScriptKind.JSX
         },
         mappings: [
           {
@@ -783,7 +784,7 @@ test('create virtual file w/ MDX layout in case of a default exported constant',
 })
 
 test('create virtual file w/ MDX layout and matching argument name', () => {
-  const module = getLanguageModule(typescript)
+  const module = getLanguageModule()
 
   const snapshot = snapshotFromLines(
     'export default function MDXLayout(properties) {}',
@@ -817,7 +818,7 @@ test('create virtual file w/ MDX layout and matching argument name', () => {
         fileName: '/test.mdx.jsx',
         languageId: 'javascriptreact',
         typescript: {
-          scriptKind: 2
+          scriptKind: typescript.ScriptKind.JSX
         },
         mappings: [
           {
@@ -892,7 +893,7 @@ test('create virtual file w/ MDX layout and matching argument name', () => {
 })
 
 test('create virtual file w/ MDX layout in case of a default export followed by a named', () => {
-  const module = getLanguageModule(typescript)
+  const module = getLanguageModule()
 
   const snapshot = snapshotFromLines(
     'export default function MDXLayout() {}',
@@ -927,7 +928,7 @@ test('create virtual file w/ MDX layout in case of a default export followed by 
         fileName: '/test.mdx.jsx',
         languageId: 'javascriptreact',
         typescript: {
-          scriptKind: 2
+          scriptKind: typescript.ScriptKind.JSX
         },
         mappings: [
           {
@@ -1003,7 +1004,7 @@ test('create virtual file w/ MDX layout in case of a default export followed by 
 })
 
 test('create virtual file w/ MDX layout in case of a default export preceded by a named', () => {
-  const module = getLanguageModule(typescript)
+  const module = getLanguageModule()
 
   const snapshot = snapshotFromLines(
     'export function named() {}',
@@ -1038,7 +1039,7 @@ test('create virtual file w/ MDX layout in case of a default export preceded by 
         fileName: '/test.mdx.jsx',
         languageId: 'javascriptreact',
         typescript: {
-          scriptKind: 2
+          scriptKind: typescript.ScriptKind.JSX
         },
         mappings: [
           {
@@ -1114,7 +1115,7 @@ test('create virtual file w/ MDX layout in case of a default export preceded by 
 })
 
 test('create virtual file w/ mdxFlowExpression', () => {
-  const module = getLanguageModule(typescript)
+  const module = getLanguageModule()
 
   const snapshot = snapshotFromLines('{Math.PI}', '')
 
@@ -1145,7 +1146,7 @@ test('create virtual file w/ mdxFlowExpression', () => {
         fileName: '/test.mdx.jsx',
         languageId: 'javascriptreact',
         typescript: {
-          scriptKind: 2
+          scriptKind: typescript.ScriptKind.JSX
         },
         mappings: [
           {
@@ -1205,7 +1206,7 @@ test('create virtual file w/ mdxFlowExpression', () => {
 })
 
 test('create virtual file w/ mdxJsxFlowElement w/ children', () => {
-  const module = getLanguageModule(typescript)
+  const module = getLanguageModule()
 
   const snapshot = snapshotFromLines(
     '<div>',
@@ -1243,7 +1244,7 @@ test('create virtual file w/ mdxJsxFlowElement w/ children', () => {
         fileName: '/test.mdx.jsx',
         languageId: 'javascriptreact',
         typescript: {
-          scriptKind: 2
+          scriptKind: typescript.ScriptKind.JSX
         },
         mappings: [
           {
@@ -1310,7 +1311,7 @@ test('create virtual file w/ mdxJsxFlowElement w/ children', () => {
 })
 
 test('create virtual file w/ mdxJsxFlowElement w/o children', () => {
-  const module = getLanguageModule(typescript)
+  const module = getLanguageModule()
 
   const snapshot = snapshotFromLines('<div />', '')
 
@@ -1372,7 +1373,7 @@ test('create virtual file w/ mdxJsxFlowElement w/o children', () => {
           ''
         ),
         typescript: {
-          scriptKind: 2
+          scriptKind: typescript.ScriptKind.JSX
         }
       },
       {
@@ -1401,7 +1402,7 @@ test('create virtual file w/ mdxJsxFlowElement w/o children', () => {
 })
 
 test('create virtual file w/ mdxJsxTextElement', () => {
-  const module = getLanguageModule(typescript)
+  const module = getLanguageModule()
 
   const snapshot = snapshotFromLines('A <div />', '')
 
@@ -1432,7 +1433,7 @@ test('create virtual file w/ mdxJsxTextElement', () => {
         fileName: '/test.mdx.jsx',
         languageId: 'javascriptreact',
         typescript: {
-          scriptKind: 2
+          scriptKind: typescript.ScriptKind.JSX
         },
         mappings: [
           {
@@ -1492,7 +1493,7 @@ test('create virtual file w/ mdxJsxTextElement', () => {
 })
 
 test('create virtual file w/ mdxTextExpression', () => {
-  const module = getLanguageModule(typescript)
+  const module = getLanguageModule()
 
   const snapshot = snapshotFromLines('3 < {Math.PI} < 4', '')
 
@@ -1523,7 +1524,7 @@ test('create virtual file w/ mdxTextExpression', () => {
         fileName: '/test.mdx.jsx',
         languageId: 'javascriptreact',
         typescript: {
-          scriptKind: 2
+          scriptKind: typescript.ScriptKind.JSX
         },
         mappings: [
           {
@@ -1583,7 +1584,7 @@ test('create virtual file w/ mdxTextExpression', () => {
 })
 
 test('create virtual file w/ syntax error', () => {
-  const module = getLanguageModule(typescript)
+  const module = getLanguageModule()
 
   const snapshot = snapshotFromLines('<', '')
 
@@ -1631,7 +1632,7 @@ test('create virtual file w/ syntax error', () => {
           ''
         ),
         typescript: {
-          scriptKind: 2
+          scriptKind: typescript.ScriptKind.JSX
         }
       },
       {
@@ -1646,7 +1647,7 @@ test('create virtual file w/ syntax error', () => {
 })
 
 test('create virtual file w/ yaml frontmatter', () => {
-  const module = getLanguageModule(typescript, [remarkFrontmatter])
+  const module = getLanguageModule([remarkFrontmatter])
 
   const snapshot = snapshotFromLines('---', 'hello: frontmatter', '---', '')
 
@@ -1694,7 +1695,7 @@ test('create virtual file w/ yaml frontmatter', () => {
           ''
         ),
         typescript: {
-          scriptKind: 2
+          scriptKind: typescript.ScriptKind.JSX
         }
       },
       {
@@ -1744,7 +1745,7 @@ test('create virtual file w/ yaml frontmatter', () => {
 })
 
 test('update virtual file', () => {
-  const module = getLanguageModule(typescript)
+  const module = getLanguageModule()
 
   const file = module.createVirtualFile(
     '/test.mdx',
@@ -1797,7 +1798,7 @@ test('update virtual file', () => {
           ''
         ),
         typescript: {
-          scriptKind: 2
+          scriptKind: typescript.ScriptKind.JSX
         }
       },
       {
@@ -1826,7 +1827,7 @@ test('update virtual file', () => {
 })
 
 test('compilation setting defaults', () => {
-  const module = getLanguageModule(typescript)
+  const module = getLanguageModule()
 
   // @ts-expect-error
   const host = module.typescript?.resolveLanguageServiceHost?.({
@@ -1846,7 +1847,7 @@ test('compilation setting defaults', () => {
 })
 
 test('compilation setting overrides', () => {
-  const module = getLanguageModule(typescript)
+  const module = getLanguageModule()
 
   // @ts-expect-error
   const host = module.typescript?.resolveLanguageServiceHost?.({
@@ -1877,5 +1878,5 @@ test('compilation setting overrides', () => {
  * @returns {typescript.IScriptSnapshot}
  */
 function snapshotFromLines(...lines) {
-  return typescript.ScriptSnapshot.fromString(lines.join('\n'))
+  return new ScriptSnapshot(lines.join('\n'))
 }


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

TypeScript isn’t needed to parse MDX into virtual files. The removal of this dependency, means that the language module could later be used in places where TypeScript is unavailable.

<!--do not edit: pr-->
