### PR TITLE
Fix return type of MDXContent in case of syntax error

### DIFF
--- a/.changeset/pink-beans-move.md
+++ b/.changeset/pink-beans-move.md
@@ -1,0 +1,5 @@
+---
+"@mdx-js/language-service": patch
+---
+
+Fix the return type of `MDXContent` in case of a syntax error

--- a/packages/language-service/lib/virtual-file.js
+++ b/packages/language-service/lib/virtual-file.js
@@ -46,7 +46,7 @@ const componentEnd = `
 /** @typedef {0 extends 1 & Props ? {} : Props} MDXContentProps */
 `
 
-const fallback = componentStart + componentEnd
+const fallback = componentStart + '<></>' + componentEnd
 
 /**
  * Visit an mdast tree with and enter and exit callback.

--- a/packages/language-service/test/language-module.js
+++ b/packages/language-service/test/language-module.js
@@ -1713,7 +1713,7 @@ test('create virtual file w/ syntax error', () => {
           ' *   The [props](https://mdxjs.com/docs/using-mdx/#props) that have been passed to the MDX component.',
           ' */',
           'export default function MDXContent(props) {',
-          '  return ',
+          '  return <></>',
           '}',
           '',
           '// @ts-ignore',


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This means that if the component is used in another file, the return type of MDXContent is inferred as JSX.Element, not void.

<!--do not edit: pr-->
