### PR TITLE
Create commands to toggle prose syntax

### DIFF
--- a/.changeset/rare-cycles-shave.md
+++ b/.changeset/rare-cycles-shave.md
@@ -1,0 +1,5 @@
+---
+"vscode-mdx": minor
+---
+
+Support the commands `mdx.toggleDelete`, `mdx.toggleEmphasis`, `mdx.toggleInlineCode`, and `mdx.toggleStrong`.

--- a/.changeset/real-eels-dance.md
+++ b/.changeset/real-eels-dance.md
@@ -1,0 +1,6 @@
+---
+"@mdx-js/language-service": minor
+"@mdx-js/language-server": minor
+---
+
+Support the commands `mdx/toggleDelete`, `mdx/toggleEmphasis`, `mdx/toggleInlineCode`, and `mdx/toggleStrong`.

--- a/packages/language-server/index.js
+++ b/packages/language-server/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 /**
+ * @typedef {import('@mdx-js/language-service').Commands} Commands
  * @typedef {import('unified').PluggableList} PluggableList
  * @typedef {import('unified').Plugin} Plugin
  */
@@ -96,8 +97,38 @@ connection.onInitialize((parameters) =>
   })
 )
 
+connection.onRequest('mdx/toggleDelete', async (parameters) => {
+  const commands = await getCommands(parameters.uri)
+  return commands.toggleDelete(parameters)
+})
+
+connection.onRequest('mdx/toggleEmphasis', async (parameters) => {
+  const commands = await getCommands(parameters.uri)
+  return commands.toggleEmphasis(parameters)
+})
+
+connection.onRequest('mdx/toggleInlineCode', async (parameters) => {
+  const commands = await getCommands(parameters.uri)
+  return commands.toggleInlineCode(parameters)
+})
+
+connection.onRequest('mdx/toggleStrong', async (parameters) => {
+  const commands = await getCommands(parameters.uri)
+  return commands.toggleStrong(parameters)
+})
+
 connection.onInitialized(() => {
   server.initialized()
 })
 
 connection.listen()
+
+/**
+ * @param {string} uri
+ * @returns {Promise<Commands>}
+ */
+async function getCommands(uri) {
+  const project = await server.projects.getProject(uri)
+  const service = project.getLanguageService()
+  return service.context.inject('mdxCommands')
+}

--- a/packages/language-service/index.js
+++ b/packages/language-service/index.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {import('./lib/service-plugin.js').Commands} Commands
+ */
+
 export {createMdxLanguagePlugin} from './lib/language-plugin.js'
 export {createMdxServicePlugin} from './lib/service-plugin.js'
 export {resolveRemarkPlugins} from './lib/tsconfig.js'

--- a/packages/language-service/lib/commands.js
+++ b/packages/language-service/lib/commands.js
@@ -1,0 +1,167 @@
+/**
+ * @typedef {import('@volar/language-service').Range} Range
+ * @typedef {import('@volar/language-service').ServiceContext} ServiceContext
+ * @typedef {import('@volar/language-service').TextEdit} TextEdit
+ * @typedef {import('mdast').Nodes} Nodes
+ */
+
+/**
+ * @typedef SyntaxToggleParams
+ *   The request parameters for LSP toggle requests.
+ * @property {string} uri
+ *   The URI of the document the request is for.
+ * @property {Range} range
+ *   The range that is selected by the user.
+ */
+
+/**
+ * @callback SyntaxToggle
+ *   A function to toggle prose markdown syntax based on the AST.
+ * @param {SyntaxToggleParams} params
+ *   The input parameters from the LSP request.
+ * @returns {TextEdit[] | undefined}
+ *   LSP text edits that should be made.
+ */
+
+import {visitParents} from 'unist-util-visit-parents'
+import {getNodeEndOffset, getNodeStartOffset} from './mdast-utils.js'
+import {VirtualMdxFile} from './virtual-file.js'
+
+/**
+ * Create a function to toggle prose syntax based on the AST.
+ *
+ * @param {ServiceContext} context
+ *   The Volar service context.
+ * @param {Nodes['type']} type
+ *   The type of the mdast node to toggle.
+ * @param {string} separator
+ *   The mdast node separator to insert.
+ * @returns {SyntaxToggle}
+ *   An LSP based syntax toggle function.
+ */
+export function createSyntaxToggle(context, type, separator) {
+  return ({range, uri}) => {
+    const file = getVirtualMdxFile(context, uri)
+
+    if (!file) {
+      return
+    }
+
+    const ast = file.ast
+
+    if (!ast) {
+      return
+    }
+
+    const doc = context.documents.get(uri, file.languageId, file.snapshot)
+    const selectionStart = doc.offsetAt(range.start)
+    const selectionEnd = doc.offsetAt(range.end)
+
+    /** @type {TextEdit[]} */
+    const edits = []
+
+    visitParents(ast, 'text', (node, ancestors) => {
+      const nodeStart = getNodeStartOffset(node)
+      const nodeEnd = getNodeEndOffset(node)
+
+      if (selectionStart < nodeStart) {
+        // Outside of this node
+        return
+      }
+
+      if (selectionEnd > nodeEnd) {
+        // Outside of this node
+        return
+      }
+
+      const matchingAncestor = ancestors.find(
+        (ancestor) => ancestor.type === type
+      )
+
+      if (matchingAncestor) {
+        const ancestorStart = getNodeStartOffset(matchingAncestor)
+        const ancestorEnd = getNodeEndOffset(matchingAncestor)
+        const firstChildStart = getNodeStartOffset(matchingAncestor.children[0])
+        const lastChildEnd = getNodeEndOffset(
+          /** @type {Nodes} */ (matchingAncestor.children.at(-1))
+        )
+
+        edits.push(
+          {
+            newText: '',
+            range: {
+              start: doc.positionAt(ancestorStart),
+              end: doc.positionAt(firstChildStart)
+            }
+          },
+          {
+            newText: '',
+            range: {
+              start: doc.positionAt(lastChildEnd),
+              end: doc.positionAt(ancestorEnd)
+            }
+          }
+        )
+      } else {
+        const valueOffset = getNodeStartOffset(node)
+        let insertStart = valueOffset
+        let insertEnd = getNodeEndOffset(node)
+
+        for (const match of node.value.matchAll(/\b/g)) {
+          if (match.index === undefined) {
+            continue
+          }
+
+          const matchOffset = valueOffset + match.index
+
+          if (matchOffset <= selectionStart) {
+            insertStart = matchOffset
+            continue
+          }
+
+          if (matchOffset >= selectionEnd) {
+            insertEnd = matchOffset
+            break
+          }
+        }
+
+        const startPosition = doc.positionAt(insertStart)
+        const endPosition = doc.positionAt(insertEnd)
+        edits.push(
+          {
+            newText: separator,
+            range: {start: startPosition, end: startPosition}
+          },
+          {
+            newText: separator,
+            range: {start: endPosition, end: endPosition}
+          }
+        )
+      }
+    })
+
+    if (edits) {
+      return edits
+    }
+  }
+}
+
+/**
+ * Get the virtual MDX file that matches a document uri.
+ *
+ * @param {ServiceContext} context
+ *   The Volar service context to use.
+ * @param {string} uri
+ *   The uri of which to find the matching virtual MDX file.
+ * @returns {VirtualMdxFile | undefined}
+ *   The matching virtual MDX file, if it exists. Otherwise undefined.
+ */
+export function getVirtualMdxFile(context, uri) {
+  const [file] = context.language.files.getVirtualFile(
+    context.env.uriToFileName(uri)
+  )
+
+  if (file instanceof VirtualMdxFile) {
+    return file
+  }
+}

--- a/packages/language-service/lib/mdast-utils.js
+++ b/packages/language-service/lib/mdast-utils.js
@@ -1,0 +1,41 @@
+/**
+ * @typedef {import('mdast').Nodes} Nodes
+ * @typedef {import('unist').Point} Point
+ * @typedef {import('unist').Position} Position
+ */
+
+/**
+ * Get the offset of a parsed unist point.
+ *
+ * @param {Point} point
+ *   The unist point of which to get the offset.
+ * @returns {number}
+ *   The offset of the unist point.
+ */
+export function getPointOffset(point) {
+  return /** @type {number} */ (point.offset)
+}
+
+/**
+ * Get the start offset of a parsed unist point.
+ *
+ * @param {Nodes} node
+ *   The unist point of which to get the start offset.
+ * @returns {number}
+ *   The start offset of the unist point.
+ */
+export function getNodeStartOffset(node) {
+  return getPointOffset(/** @type {Position} */ (node.position).start)
+}
+
+/**
+ * Get the end offset of a parsed unist point.
+ *
+ * @param {Nodes} node
+ *   The unist point of which to get the end offset.
+ * @returns {number}
+ *   The end offset of the unist point.
+ */
+export function getNodeEndOffset(node) {
+  return getPointOffset(/** @type {Position} */ (node.position).end)
+}

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -42,6 +42,7 @@
     "remark-parse": "^11.0.0",
     "unified": "^11.0.0",
     "unist-util-lsp": "^2.0.0",
+    "unist-util-visit-parents": "^6.0.0",
     "vfile-message": "^4.0.0",
     "vscode-uri": "^3.0.0"
   },

--- a/packages/vscode-mdx/package.json
+++ b/packages/vscode-mdx/package.json
@@ -153,6 +153,26 @@
         }
       }
     ],
+    "keybindings": [
+      {
+        "command": "mdx.toggleEmphasis",
+        "key": "ctrl+i",
+        "mac": "cmd+i",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == mdx"
+      },
+      {
+        "command": "mdx.toggleDelete",
+        "key": "alt+shift+5",
+        "mac": "cmd+shift+x",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == mdx"
+      },
+      {
+        "command": "mdx.toggleStrong",
+        "key": "ctrl+b",
+        "mac": "cmd+b",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == mdx"
+      }
+    ],
     "languages": [
       {
         "id": "mdx",
@@ -180,6 +200,26 @@
         "command": "mdx.selectTypescriptVersion",
         "title": "Select TypeScript version…",
         "category": "MDX"
+      },
+      {
+        "command": "mdx.toggleDelete",
+        "title": "Toggle Delete",
+        "category": "MDX"
+      },
+      {
+        "command": "mdx.toggleEmphasis",
+        "title": "Toggle Emphasis",
+        "category": "MDX"
+      },
+      {
+        "command": "mdx.toggleInlineCode",
+        "title": "Toggle Inline Code",
+        "category": "MDX"
+      },
+      {
+        "command": "mdx.toggleStrong",
+        "title": "Toggle Strong",
+        "category": "MDX"
       }
     ],
     "menus": {
@@ -187,6 +227,28 @@
         {
           "command": "mdx.selectTypescriptVersion",
           "when": "editorLangId == mdx"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "mdx.toggleDelete",
+          "when": "editorTextFocus && !editorReadonly && editorLangId == mdx",
+          "group": "1_modification"
+        },
+        {
+          "command": "mdx.toggleEmphasis",
+          "when": "editorTextFocus && !editorReadonly && editorLangId == mdx",
+          "group": "1_modification"
+        },
+        {
+          "command": "mdx.toggleInlineCode",
+          "when": "editorTextFocus && !editorReadonly && editorLangId == mdx",
+          "group": "1_modification"
+        },
+        {
+          "command": "mdx.toggleStrong",
+          "when": "editorTextFocus && !editorReadonly && editorLangId == mdx",
+          "group": "1_modification"
         }
       ]
     },

--- a/packages/vscode-mdx/src/extension.js
+++ b/packages/vscode-mdx/src/extension.js
@@ -1,4 +1,5 @@
 /**
+ * @typedef {import('@volar/language-server').TextEdit} TextEdit
  * @typedef {import('@volar/vscode').LabsInfo} LabsInfo
  * @typedef {import('vscode').ExtensionContext} ExtensionContext
  */
@@ -11,7 +12,14 @@ import {
   createLabsInfo,
   getTsdk
 } from '@volar/vscode'
-import {Disposable, workspace, window, ProgressLocation} from 'vscode'
+import {
+  commands,
+  window,
+  workspace,
+  Disposable,
+  ProgressLocation,
+  WorkspaceEdit
+} from 'vscode'
 import {LanguageClient, TransportKind} from '@volar/vscode/node.js'
 
 /**
@@ -112,6 +120,10 @@ async function startServer(context) {
         disposable = Disposable.from(
           activateAutoInsertion('mdx', client),
           activateDocumentDropEdit('mdx', client),
+          activateMdxToggleCommand('toggleDelete'),
+          activateMdxToggleCommand('toggleEmphasis'),
+          activateMdxToggleCommand('toggleInlineCode'),
+          activateMdxToggleCommand('toggleStrong'),
           activateTsVersionStatusItem(
             'mdx',
             'mdx.selectTypescriptVersion',
@@ -123,4 +135,40 @@ async function startServer(context) {
       }
     )
   }
+}
+
+/**
+ * @param {string} command
+ * @returns {Disposable}
+ */
+function activateMdxToggleCommand(command) {
+  return commands.registerCommand('mdx.' + command, async () => {
+    const editor = window.activeTextEditor
+    if (!editor) {
+      return
+    }
+
+    const document = editor.document
+    const beforeVersion = document.version
+
+    /** @type {TextEdit[] | undefined} */
+    const response = await client.sendRequest('mdx/' + command, {
+      uri: String(document.uri),
+      range: client.code2ProtocolConverter.asRange(editor.selection)
+    })
+
+    if (!response?.length) {
+      return
+    }
+
+    const textEdits = await client.protocol2CodeConverter.asTextEdits(response)
+
+    if (beforeVersion !== document.version) {
+      return
+    }
+
+    const workspaceEdit = new WorkspaceEdit()
+    workspaceEdit.set(document.uri, textEdits)
+    workspace.applyEdit(workspaceEdit, {})
+  })
 }


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

The prose syntax is based on the current text selection and the AST. If the selection is within range of the syntax that’s toggled, the syntax is removed. Otherwise the selected text is expanded to include full words and wrapped.

The supported syntaxes are:

| mdast node | LSP command | VSCode command | Keyboard shortcut | macOS shortcut |
| --- | --- | --- | --- | --- |
| `delete` | `mdx/toggleDelete` | `mdx.toggleDelete`  | <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>5</kbd> | <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>X</kbd>
| `emphasis` | `mdx/toggleEmphasis` | `mdx.toggleEmphasis`  | <kbd>Ctrl</kbd> + <kbd>I</kbd> | <kbd>Cmd</kbd> + <kbd>I</kbd>
| `inlineCode` | `mdx/toggleInlineCode` | `mdx.toggleInlineCode`  | 
| `strong` | `mdx/toggleStrong` | `mdx.toggleStrong`  | <kbd>Ctrl</kbd> + <kbd>B</kbd> | <kbd>Cmd</kbd> + <kbd>B</kbd>

Closes #353

<!--do not edit: pr-->
