### PR TITLE
Fix the language server tests on Windows

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -43,9 +43,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "@types/normalize-path": "^3.0.0",
     "@volar/test-utils": "2.0.0-alpha.14",
-    "normalize-path": "^3.0.0",
     "unified": "^11.0.0"
   }
 }

--- a/packages/language-server/test/document-link.test.js
+++ b/packages/language-server/test/document-link.test.js
@@ -31,7 +31,9 @@ test('resolve markdown link references', async () => {
         end: {line: 0, character: 12}
       },
       tooltip: 'Go to link definition',
-      target: fixtureUri('node16/link-reference.mdx?virtualCodeId=md#L3,8'),
+      target: fixtureUri(
+        'node16/link-reference.mdx?virtualCodeId=md#L3,8'
+      ).replace('%3A', ':'),
       data: {
         uri: fixtureUri('node16/link-reference.mdx'),
         original: {
@@ -43,7 +45,10 @@ test('resolve markdown link references', async () => {
               pathText: 'mdx',
               resource: {
                 $mid: 1,
-                path: fixturePath('node16/link-reference.mdx'),
+                path: fixturePath('node16/link-reference.mdx').replace(
+                  /^\/?/,
+                  '/'
+                ),
                 query: 'virtualCodeId=md',
                 scheme: 'file'
               },

--- a/packages/language-server/test/utils.js
+++ b/packages/language-server/test/utils.js
@@ -5,11 +5,9 @@
 
 import {createRequire} from 'node:module'
 import path from 'node:path'
-import {fileURLToPath} from 'node:url'
 import {URI, Utils} from 'vscode-uri'
-import {startLanguageServer} from '@volar/test-utils'
 // eslint-disable-next-line import/order
-import normalizePath from 'normalize-path'
+import {startLanguageServer} from '@volar/test-utils'
 
 const require = createRequire(import.meta.url)
 const pkgPath = new URL('../package.json', import.meta.url)
@@ -45,5 +43,5 @@ export function fixtureUri(fileName) {
  * @returns {string}
  */
 export function fixturePath(fileName) {
-  return normalizePath(fileURLToPath(fixtureUri(fileName)))
+  return URI.parse(fixtureUri(fileName)).fsPath.replaceAll('\\', '/')
 }


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This replaces the use of `URL` with `vscode-uri`. This handles Windows paths better than the combination of both.

<!--do not edit: pr-->
