### PR TITLE
Support strict type checking in MDX

### DIFF
--- a/.changeset/four-cats-scream.md
+++ b/.changeset/four-cats-scream.md
@@ -1,0 +1,7 @@
+---
+"@mdx-js/language-service": patch
+"@mdx-js/language-server": patch
+"vscode-mdx": patch
+---
+
+Support `tsconfig.json` option `mdx.checkMdx`

--- a/packages/language-server/index.js
+++ b/packages/language-server/index.js
@@ -65,6 +65,7 @@ connection.onInitialize((parameters) =>
 
       /** @type {PluggableList | undefined} */
       let plugins
+      let checkMdx = false
       let jsxImportSource = 'react'
 
       if (configFileName) {
@@ -87,11 +88,16 @@ connection.onInitialize((parameters) =>
               loadPlugin(name, {prefix: 'remark', cwd})
             )
         )
+        checkMdx = Boolean(commandLine.raw?.mdx?.checkMdx)
         jsxImportSource = commandLine.options.jsxImportSource || jsxImportSource
       }
 
       return [
-        createMdxLanguagePlugin(plugins || defaultPlugins, jsxImportSource)
+        createMdxLanguagePlugin(
+          plugins || defaultPlugins,
+          checkMdx,
+          jsxImportSource
+        )
       ]
     }
   })

--- a/packages/language-service/lib/language-plugin.js
+++ b/packages/language-service/lib/language-plugin.js
@@ -14,12 +14,18 @@ import {VirtualMdxCode} from './virtual-code.js'
  * @param {PluggableList} [plugins]
  *   A list of remark syntax plugins. Only syntax plugins are supported.
  *   Transformers are unused.
+ * @param {boolean} checkMdx
+ *   If true, check MDX files strictly.
  * @param {string} jsxImportSource
  *   The JSX import source to use in the embedded JavaScript file.
  * @returns {LanguagePlugin}
  *   A Volar language plugin to support MDX.
  */
-export function createMdxLanguagePlugin(plugins, jsxImportSource = 'react') {
+export function createMdxLanguagePlugin(
+  plugins,
+  checkMdx = false,
+  jsxImportSource = 'react'
+) {
   const processor = unified().use(remarkParse).use(remarkMdx)
   if (plugins) {
     processor.use(plugins)
@@ -30,7 +36,12 @@ export function createMdxLanguagePlugin(plugins, jsxImportSource = 'react') {
   return {
     createVirtualCode(fileId, languageId, snapshot) {
       if (languageId === 'mdx') {
-        return new VirtualMdxCode(snapshot, processor, jsxImportSource)
+        return new VirtualMdxCode(
+          snapshot,
+          processor,
+          checkMdx,
+          jsxImportSource
+        )
       }
     },
 

--- a/packages/language-service/test/language-module.js
+++ b/packages/language-service/test/language-module.js
@@ -2262,8 +2262,96 @@ test('compilation setting overrides', () => {
   })
 })
 
+test('support checkMdx', () => {
+  const plugin = createMdxLanguagePlugin(undefined, true)
+
+  const snapshot = snapshotFromLines('')
+
+  const code = plugin.createVirtualCode('/test.mdx', 'mdx', snapshot)
+
+  assert.ok(code instanceof VirtualMdxCode)
+  assert.equal(code.id, 'mdx')
+  assert.equal(code.languageId, 'mdx')
+  assert.ifError(code.error)
+  assert.equal(code.snapshot, snapshot)
+  assert.deepEqual(code.mappings, [
+    {
+      sourceOffsets: [0],
+      generatedOffsets: [0],
+      lengths: [snapshot.getLength()],
+      data: {
+        completion: true,
+        format: true,
+        navigation: true,
+        semantic: true,
+        structure: true,
+        verification: true
+      }
+    }
+  ])
+  assert.deepEqual(code.embeddedCodes, [
+    {
+      embeddedCodes: [],
+      id: 'jsx',
+      languageId: 'javascriptreact',
+      mappings: [],
+      snapshot: snapshotFromLines(
+        '// @ts-check',
+        '/* @jsxRuntime automatic',
+        '@jsxImportSource react */',
+        '',
+        '/**',
+        ' * @deprecated',
+        ' *   Do not use.',
+        ' *',
+        ' * @param {{readonly [K in keyof MDXContentProps]: MDXContentProps[K]}} props',
+        ' *   The [props](https://mdxjs.com/docs/using-mdx/#props) that have been passed to the MDX component.',
+        ' */',
+        'function _createMdxContent(props) {',
+        '  return <></>',
+        '}',
+        '',
+        '/**',
+        ' * Render the MDX contents.',
+        ' *',
+        ' * @param {{readonly [K in keyof MDXContentProps]: MDXContentProps[K]}} props',
+        ' *   The [props](https://mdxjs.com/docs/using-mdx/#props) that have been passed to the MDX component.',
+        ' */',
+        'export default function MDXContent(props) {',
+        '  return <_createMdxContent {...props} />',
+        '}',
+        '',
+        '// @ts-ignore',
+        '/** @typedef {0 extends 1 & Props ? {} : Props} MDXContentProps */',
+        ''
+      )
+    },
+    {
+      embeddedCodes: [],
+      id: 'md',
+      languageId: 'markdown',
+      mappings: [
+        {
+          sourceOffsets: [],
+          generatedOffsets: [],
+          lengths: [],
+          data: {
+            completion: true,
+            format: false,
+            navigation: true,
+            semantic: true,
+            structure: true,
+            verification: true
+          }
+        }
+      ],
+      snapshot: snapshotFromLines('')
+    }
+  ])
+})
+
 test('support custom jsxImportSource', () => {
-  const plugin = createMdxLanguagePlugin(undefined, 'preact')
+  const plugin = createMdxLanguagePlugin(undefined, false, 'preact')
 
   const snapshot = snapshotFromLines('')
 

--- a/packages/vscode-mdx/tsconfig.schema.json
+++ b/packages/vscode-mdx/tsconfig.schema.json
@@ -2,7 +2,16 @@
   "properties": {
     "mdx": {
       "title": "MDX language server options",
-      "$ref": "https://json.schemastore.org/remarkrc.json"
+      "properties": {
+        "checkMdx": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable error reporting in type-checked MDX files."
+        },
+        "plugins": {
+          "$ref": "https://json.schemastore.org/remarkrc.json#/properties/plugins"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

The MDX language service now accepts the option `checkMdx`. When this is enabled, it tells TypeScript to type check the virtual JSX by inserting a `@ts-check` comment. The language server reads this as the option `mdx.checkMdx` from `tsconfig.json`.

Closes #352

<!--do not edit: pr-->
