### PR TITLE
Fix duplicate comment auto closing

### DIFF
--- a/.changeset/mean-avocados-accept.md
+++ b/.changeset/mean-avocados-accept.md
@@ -1,0 +1,5 @@
+---
+"vscode-mdx": patch
+---
+
+Fix duplicate comment auto closing

--- a/packages/vscode-mdx/language-configuration.json
+++ b/packages/vscode-mdx/language-configuration.json
@@ -27,14 +27,9 @@
       "notIn": ["string"]
     },
     {
-      "open": "/**",
-      "close": " */",
+      "open": "/*",
+      "close": "*/",
       "notIn": ["string"]
-    },
-    {
-      "open": "{/*",
-      "close": "*/}",
-      "notIn": ["string", "comment"]
     }
   ],
   "surroundingPairs": [


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Block comments were auto closed twice, which leads to invalid MDX. Now it’s auto closed only once.

<!--do not edit: pr-->
