### PR TITLE
Using syntax-only TS service plugin

### DIFF
--- a/.changeset/fuzzy-poets-wonder.md
+++ b/.changeset/fuzzy-poets-wonder.md
@@ -2,4 +2,4 @@
 "@mdx-js/language-server": patch
 ---
 
-Use syntax-only TypeScript plugin.
+Use syntax-only TypeScript service plugin.

--- a/.changeset/fuzzy-poets-wonder.md
+++ b/.changeset/fuzzy-poets-wonder.md
@@ -1,0 +1,5 @@
+---
+"@mdx-js/language-server": patch
+---
+
+Use syntax-only TypeScript plugin.

--- a/packages/language-server/index.js
+++ b/packages/language-server/index.js
@@ -25,6 +25,7 @@ import {loadPlugin} from 'load-plugin'
 import remarkFrontmatter from 'remark-frontmatter'
 import remarkGfm from 'remark-gfm'
 import {create as createMarkdownServicePlugin} from 'volar-service-markdown'
+import {create as createTypeScriptServicePlugins} from 'volar-service-typescript'
 import {create as createTypeScriptSyntacticServicePlugin} from 'volar-service-typescript/lib/plugins/syntactic.js'
 
 process.title = 'mdx-language-server'
@@ -69,15 +70,21 @@ connection.onInitialize((parameters) => {
       ],
 
       getServicePlugins() {
-        const plugins = [
+        let plugins = [
           createMarkdownServicePlugin({
             getDiagnosticOptions(document, context) {
               return context.env.getConfiguration?.('mdx.validate')
             }
           }),
-          createMdxServicePlugin(),
-          createTypeScriptSyntacticServicePlugin(typescript)
+          createMdxServicePlugin()
         ]
+
+        if (tsEnabled) {
+          plugins = plugins.concat(createTypeScriptServicePlugins(typescript, {}))
+        }
+        else {
+          plugins.push(createTypeScriptSyntacticServicePlugin(typescript))
+        }
 
         return plugins
       },

--- a/packages/language-server/index.js
+++ b/packages/language-server/index.js
@@ -25,7 +25,7 @@ import {loadPlugin} from 'load-plugin'
 import remarkFrontmatter from 'remark-frontmatter'
 import remarkGfm from 'remark-gfm'
 import {create as createMarkdownServicePlugin} from 'volar-service-markdown'
-import {create as createTypeScriptServicePlugins} from 'volar-service-typescript'
+import {create as createTypeScriptServicePlugin} from 'volar-service-typescript'
 import {create as createTypeScriptSyntacticServicePlugin} from 'volar-service-typescript/lib/plugins/syntactic.js'
 
 process.title = 'mdx-language-server'
@@ -70,23 +70,17 @@ connection.onInitialize((parameters) => {
       ],
 
       getServicePlugins() {
-        let plugins = [
+        return [
           createMarkdownServicePlugin({
             getDiagnosticOptions(document, context) {
               return context.env.getConfiguration?.('mdx.validate')
             }
           }),
-          createMdxServicePlugin()
+          createMdxServicePlugin(),
+          tsEnabled
+            ? createTypeScriptServicePlugin(typescript, {})
+            : createTypeScriptSyntacticServicePlugin(typescript)
         ]
-
-        if (tsEnabled) {
-          plugins = plugins.concat(createTypeScriptServicePlugins(typescript, {}))
-        }
-        else {
-          plugins.push(createTypeScriptSyntacticServicePlugin(typescript))
-        }
-
-        return plugins
       },
 
       async getLanguagePlugins(serviceEnvironment, projectContext) {

--- a/packages/language-server/index.js
+++ b/packages/language-server/index.js
@@ -70,17 +70,22 @@ connection.onInitialize((parameters) => {
       ],
 
       getServicePlugins() {
-        return [
+        const plugins = [
           createMarkdownServicePlugin({
             getDiagnosticOptions(document, context) {
               return context.env.getConfiguration?.('mdx.validate')
             }
           }),
-          createMdxServicePlugin(),
-          tsEnabled
-            ? createTypeScriptServicePlugin(typescript, {})
-            : createTypeScriptSyntacticServicePlugin(typescript)
+          createMdxServicePlugin()
         ]
+
+        if (tsEnabled) {
+          plugins.push(...createTypeScriptServicePlugin(typescript, {}))
+        } else {
+          plugins.push(createTypeScriptSyntacticServicePlugin(typescript))
+        }
+
+        return plugins
       },
 
       async getLanguagePlugins(serviceEnvironment, projectContext) {

--- a/packages/language-server/index.js
+++ b/packages/language-server/index.js
@@ -25,7 +25,7 @@ import {loadPlugin} from 'load-plugin'
 import remarkFrontmatter from 'remark-frontmatter'
 import remarkGfm from 'remark-gfm'
 import {create as createMarkdownServicePlugin} from 'volar-service-markdown'
-import {create as createTypeScriptServicePlugin} from 'volar-service-typescript'
+import {create as createTypeScriptSyntacticServicePlugin} from 'volar-service-typescript/lib/plugins/syntactic.js'
 
 process.title = 'mdx-language-server'
 
@@ -76,7 +76,7 @@ connection.onInitialize((parameters) => {
             }
           }),
           createMdxServicePlugin(),
-          createTypeScriptServicePlugin(typescript)
+          createTypeScriptSyntacticServicePlugin(typescript)
         ]
 
         return plugins

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -37,8 +37,8 @@
     "load-plugin": "^5.0.0",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.0",
-    "volar-service-markdown": "0.0.31",
-    "volar-service-typescript": "0.0.31",
+    "volar-service-markdown": "0.0.32",
+    "volar-service-typescript": "0.0.32",
     "vscode-uri": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/language-server/test/initialize.test.js
+++ b/packages/language-server/test/initialize.test.js
@@ -42,12 +42,16 @@ test('initialize', async () => {
       colorProvider: true,
       completionProvider: {
         resolveProvider: true,
-        triggerCharacters: ['.', '/', '#']
+        triggerCharacters: ['.', '/', '#', '"', "'", '`', '<', '@', ' ', '*']
       },
       definitionProvider: true,
       documentFormattingProvider: true,
       documentHighlightProvider: true,
       documentLinkProvider: {resolveProvider: true},
+      documentOnTypeFormattingProvider: {
+        firstTriggerCharacter: ';',
+        moreTriggerCharacter: ['}', '\n']
+      },
       documentRangeFormattingProvider: true,
       documentSymbolProvider: true,
       foldingRangeProvider: true,
@@ -102,8 +106,8 @@ test('initialize', async () => {
         range: true
       },
       signatureHelpProvider: {
-        retriggerCharacters: [],
-        triggerCharacters: []
+        retriggerCharacters: [')'],
+        triggerCharacters: ['(', ',', '<']
       },
       textDocumentSync: 2,
       typeDefinitionProvider: true,

--- a/packages/language-server/test/initialize.test.js
+++ b/packages/language-server/test/initialize.test.js
@@ -42,16 +42,12 @@ test('initialize', async () => {
       colorProvider: true,
       completionProvider: {
         resolveProvider: true,
-        triggerCharacters: ['.', '/', '#', '"', "'", '`', '<', '@', ' ', '*']
+        triggerCharacters: ['.', '/', '#']
       },
       definitionProvider: true,
       documentFormattingProvider: true,
       documentHighlightProvider: true,
       documentLinkProvider: {resolveProvider: true},
-      documentOnTypeFormattingProvider: {
-        firstTriggerCharacter: ';',
-        moreTriggerCharacter: ['}', '\n']
-      },
       documentRangeFormattingProvider: true,
       documentSymbolProvider: true,
       foldingRangeProvider: true,
@@ -106,8 +102,8 @@ test('initialize', async () => {
         range: true
       },
       signatureHelpProvider: {
-        retriggerCharacters: [')'],
-        triggerCharacters: ['(', ',', '<']
+        retriggerCharacters: [],
+        triggerCharacters: []
       },
       textDocumentSync: 2,
       typeDefinitionProvider: true,


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Since mdx-analyzer is now integrated with tsserver, the language server no longer requires complete TS language features. Using `volar-service-typescript/lib/plugins/syntactic.js` instead of the completed service plugin can avoid the language server registering unnecessary trigger characters.

Initialize Result before PR:

```json
		"signatureHelpProvider": {
			"triggerCharacters": [
				"(",
				",",
				"<"
			],
			"retriggerCharacters": [
				")"
			]
		},
		"completionProvider": {
			"triggerCharacters": [
				".",
				"\"",
				"'",
				"`",
				"/",
				"<",
				"@",
				"#",
				" ",
				"*",
				"-",
				":",
				"=",
				">",
				"+",
				"^",
				"(",
				")",
				"[",
				"]",
				"$",
				"{",
				"}"
			],
			"resolveProvider": true
		},
```

Initialize Result after PR:

```json
		"signatureHelpProvider": {
			"triggerCharacters": [],
			"retriggerCharacters": []
		},
		"completionProvider": {
			"triggerCharacters": [
				".",
				"/",
				"#"
			],
			"resolveProvider": true
		},
```