### PR TITLE
Fix the file lookup in syntax toggles

### DIFF
--- a/.changeset/purple-tomatoes-drop.md
+++ b/.changeset/purple-tomatoes-drop.md
@@ -1,0 +1,5 @@
+---
+"@mdx-js/language-service": patch
+---
+
+Fix the file lookup in syntax toggles

--- a/packages/language-service/lib/commands.js
+++ b/packages/language-service/lib/commands.js
@@ -41,7 +41,8 @@ import {VirtualMdxCode} from './virtual-code.js'
  */
 export function createSyntaxToggle(context, type, separator) {
   return ({range, uri}) => {
-    const [file] = context.documents.getVirtualCodeByUri(uri)
+    const sourceFile = context.language.files.get(uri)
+    const file = sourceFile?.generated?.code
 
     if (!(file instanceof VirtualMdxCode)) {
       return


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Without this fix, the syntax toggles didn’t do anything at all.

<!--do not edit: pr-->
