### PR TITLE
Disable markdown based linting by default

### DIFF
--- a/.changeset/silver-boats-kneel.md
+++ b/.changeset/silver-boats-kneel.md
@@ -1,0 +1,5 @@
+---
+"vscode-mdx": patch
+---
+
+Set markdown validation defaults to `"ignore"`

--- a/packages/vscode-mdx/package.json
+++ b/packages/vscode-mdx/package.json
@@ -90,7 +90,7 @@
               "warning",
               "error"
             ],
-            "default": "warning",
+            "default": "ignore",
             "markdownDescription": "Diagnostic level for invalid reference links, e.g. `[text][no-such-ref]`."
           },
           "mdx.validate.validateFragmentLinks": {
@@ -100,7 +100,7 @@
               "warning",
               "error"
             ],
-            "default": "warning",
+            "default": "ignore",
             "markdownDescription": "Diagnostic level for fragments links to headers in the current file that don’t exist, e.g. `[text](#no-such-header)`."
           },
           "mdx.validate.validateFileLinks": {
@@ -110,7 +110,7 @@
               "warning",
               "error"
             ],
-            "default": "warning",
+            "default": "ignore",
             "markdownDescription": "Diagnostic level for links to local files that don’t exist, e.g. `[text](./no-such-file.png)`."
           },
           "mdx.validate.validateMarkdownFileLinkFragments": {
@@ -120,7 +120,7 @@
               "warning",
               "error"
             ],
-            "default": "warning",
+            "default": "ignore",
             "markdownDescription": "Diagnostic level for the fragment part of links to other local markdown files , e.g. `[text](./file.md#no-such-header)`."
           },
           "mdx.validate.validateUnusedLinkDefinitions": {
@@ -130,7 +130,7 @@
               "warning",
               "error"
             ],
-            "default": "warning",
+            "default": "ignore",
             "markdownDescription": "Diagnostic level for link definitions that aren’t used anywhere. `[never-used]: http://example.com`."
           },
           "mdx.validate.validateDuplicateLinkDefinitions": {
@@ -140,7 +140,7 @@
               "warning",
               "error"
             ],
-            "default": "warning",
+            "default": "ignore",
             "markdownDescription": "Diagnostic level for duplicate link definitions."
           },
           "mdx.validate.ignoreLinks": {


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

VSCode does this for markdown files too. Some validation results are not wanted. Some are even false positives.

Closes #424

<!--do not edit: pr-->
