### PR TITLE
Only watch TS related file extensions if needed

### DIFF
--- a/.changeset/hot-lies-wink.md
+++ b/.changeset/hot-lies-wink.md
@@ -1,0 +1,5 @@
+---
+"@mdx-js/language-server": patch
+---
+
+Avoid redundant file watchers when TypeScript is disabled.

--- a/packages/language-server/index.js
+++ b/packages/language-server/index.js
@@ -35,12 +35,11 @@ process.title = 'mdx-language-server'
 const defaultPlugins = [[remarkFrontmatter, ['toml', 'yaml']], remarkGfm]
 const connection = createConnection()
 const server = createServer(connection)
+let tsEnabled = false
 
 connection.onInitialize(async (parameters) => {
   const tsdk = parameters.initializationOptions?.typescript?.tsdk
-  const tsEnabled = Boolean(
-    parameters.initializationOptions?.typescript?.enabled
-  )
+  tsEnabled = Boolean(parameters.initializationOptions?.typescript?.enabled)
   assert(
     typeof tsdk === 'string',
     'Missing initialization option typescript.tsdk'
@@ -146,21 +145,23 @@ connection.onRequest('mdx/toggleStrong', async (parameters) => {
 })
 
 connection.onInitialized(() => {
-  server.initialized()
-  server.watchFiles([
-    `**/*.{${[
+  const extensions = ['mdx']
+  if (tsEnabled) {
+    extensions.push(
       'cjs',
       'cts',
       'js',
       'jsx',
       'json',
-      'mdx',
       'mjs',
       'mts',
       'ts',
       'tsx'
-    ].join(',')}}`
-  ])
+    )
+  }
+
+  server.initialized()
+  server.watchFiles([`**/*.{${extensions.join(',')}}`])
 })
 
 connection.listen()


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

If TypeScript isn’t enabled in the language server, there’s no need to watch file extension other than `mdx`.

<!--do not edit: pr-->
