### PR TITLE
Fix resolving MDX options from tsconfig.json

### DIFF
--- a/.changeset/eighty-masks-matter.md
+++ b/.changeset/eighty-masks-matter.md
@@ -1,0 +1,5 @@
+---
+'@mdx-js/language-server': patch
+---
+
+Fix resolving MDX options from `tsconfig.json`.

--- a/packages/language-server/index.js
+++ b/packages/language-server/index.js
@@ -18,7 +18,6 @@ import {
 import {
   createConnection,
   createServer,
-  createSimpleProjectProvider,
   createTypeScriptProjectProvider,
   loadTsdkByPath
 } from '@volar/language-server/node.js'
@@ -53,13 +52,11 @@ connection.onInitialize(async (parameters) => {
   return server.initialize(
     parameters,
     getLanguageServicePlugins(),
-    tsEnabled
-      ? createTypeScriptProjectProvider(
-          typescript,
-          diagnosticMessages,
-          (_, {configFileName}) => getLanguagePlugins(configFileName)
-        )
-      : createSimpleProjectProvider(await getLanguagePlugins(undefined))
+    createTypeScriptProjectProvider(
+      typescript,
+      diagnosticMessages,
+      (serviceEnv, {configFileName}) => getLanguagePlugins(configFileName)
+    )
   )
 
   function getLanguageServicePlugins() {


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

We need the config file name provided by `createTypeScriptProjectProvider()` in order to resolve options from `tsconfig.json`.

<!--do not edit: pr-->
