### PR TITLE
Document syntax highlighting for MDX code blocks

### DIFF
--- a/.changeset/khaki-coats-press.md
+++ b/.changeset/khaki-coats-press.md
@@ -1,0 +1,5 @@
+---
+'vscode-mdx': patch
+---
+
+Document how to support custom languages in MDX code blocks.

--- a/packages/vscode-mdx/README.md
+++ b/packages/vscode-mdx/README.md
@@ -69,20 +69,21 @@ However, it’s impossible to support all languages within the MDX extension.
 Instead, if an extensions adds support for a language, it can add support for
 MDX code blocks.
 
-To support MDX code blocks in your Visual Studio Code extension, use the
-following template.
-Replace `LANGUAGE` with your actual language and remove comments.
-Save the file to `syntaxes/mdx.LANGUAGE.tmLanguage.json`.
+The following example adds support for syntax highlighting MDX code blocks
+tagged with `mermaid`.
+You can use this example and replace `mermaid` with the appropriate values to
+support your own language.
+Save the file to `syntaxes/mdx.mermaid.tmLanguage.json`.
 
 ```jsonc
 {
   "fileTypes": [],
   // This can be something else.
-  "scopeName": "mdx.LANGUAGE.codeblock",
+  "scopeName": "mdx.mermaid.codeblock",
   "injectionSelector": "L:source.mdx",
   "patterns": [
     {
-      "begin": "(?:^|\\G)[\\t ]*(`{3,})(?:[\\t ]*((?i:(?:.*\\.)?LANGUAGE))(?:[\\t ]+((?:[^\\n\\r`])+))?)(?:[\\t ]*$)",
+      "begin": "(?:^|\\G)[\\t ]*(`{3,})(?:[\\t ]*((?i:(?:.*\\.)?mermaid))(?:[\\t ]+((?:[^\\n\\r`])+))?)(?:[\\t ]*$)",
       "beginCaptures": {
         "1": {
           "name": "string.other.begin.code.fenced.mdx"
@@ -91,22 +92,22 @@ Save the file to `syntaxes/mdx.LANGUAGE.tmLanguage.json`.
           "name": "entity.name.function.mdx"
         }
       },
-      "contentName": "meta.embedded.LANGUAGE",
+      "contentName": "meta.embedded.mermaid",
       "end": "(\\1)(?:[\\t ]*$)",
       "endCaptures": {
         "1": {
           "name": "string.other.end.code.fenced.mdx"
         }
       },
-      "name": "markup.code.LANGUAGE.mdx",
+      "name": "markup.code.mermaid.mdx",
       "patterns": [
         {
-          "include": "source.LANGUAGE"
+          "include": "source.mermaid"
         }
       ]
     },
     {
-      "begin": "(?:^|\\G)[\\t ]*(~{3,})(?:[\\t ]*((?i:(?:.*\\.)?LANGUAGE))(?:[\\t ]+((?:[^\\n\\r])+))?)(?:[\\t ]*$)",
+      "begin": "(?:^|\\G)[\\t ]*(~{3,})(?:[\\t ]*((?i:(?:.*\\.)?mermaid))(?:[\\t ]+((?:[^\\n\\r])+))?)(?:[\\t ]*$)",
       "beginCaptures": {
         "1": {
           "name": "string.other.begin.code.fenced.mdx"
@@ -115,17 +116,17 @@ Save the file to `syntaxes/mdx.LANGUAGE.tmLanguage.json`.
           "name": "entity.name.function.mdx"
         }
       },
-      "contentName": "meta.embedded.LANGUAGE",
+      "contentName": "meta.embedded.mermaid",
       "end": "(\\1)(?:[\\t ]*$)",
       "endCaptures": {
         "1": {
           "name": "string.other.end.code.fenced.mdx"
         }
       },
-      "name": "markup.code.LANGUAGE.mdx",
+      "name": "markup.code.mermaid.mdx",
       "patterns": [
         {
-          "include": "source.LANGUAGE"
+          "include": "source.mermaid"
         }
       ]
     }
@@ -134,7 +135,7 @@ Save the file to `syntaxes/mdx.LANGUAGE.tmLanguage.json`.
 ```
 
 In `package.json`, add the following section.
-Replace `LANGUAGE` with your actual language and remove comments.
+Replace `mermaid` with your actual language and remove comments.
 
 ```jsonc
 {
@@ -142,13 +143,13 @@ Replace `LANGUAGE` with your actual language and remove comments.
     "grammars": [
       {
         // This must match the scopeName in the tmLanguage file.
-        "scopeName": "mdx.LANGUAGE.codeblock",
-        "path": "./syntaxes/mdx.LANGUAGE.tmLanguage.json",
+        "scopeName": "mdx.mermaid.codeblock",
+        "path": "./syntaxes/mdx.mermaid.tmLanguage.json",
         "injectTo": [
           "source.mdx"
         ],
         "embeddedLanguages": {
-          "source.LANGUAGE": "LANGUAGE",
+          "source.mermaid": "mermaid",
         }
       }
     ]

--- a/packages/vscode-mdx/README.md
+++ b/packages/vscode-mdx/README.md
@@ -74,7 +74,7 @@ following template.
 Replace `LANGUAGE` with your actual language and remove comments.
 Save the file to `syntaxes/mdx.LANGUAGE.tmLanguage.json`.
 
-````jsonc
+```jsonc
 {
   "fileTypes": [],
   // This can be something else.
@@ -82,68 +82,56 @@ Save the file to `syntaxes/mdx.LANGUAGE.tmLanguage.json`.
   "injectionSelector": "L:source.mdx",
   "patterns": [
     {
-      // This references the repository key below.
-      "include": "#LANGUAGE-code-block"
-    }
-  ],
-  "repository": {
-    "LANGUAGE-code-block": {
+      "begin": "(?:^|\\G)[\\t ]*(`{3,})(?:[\\t ]*((?i:(?:.*\\.)?LANGUAGE))(?:[\\t ]+((?:[^\\n\\r`])+))?)(?:[\\t ]*$)",
+      "beginCaptures": {
+        "1": {
+          "name": "string.other.begin.code.fenced.mdx"
+        },
+        "2": {
+          "name": "entity.name.function.mdx"
+        }
+      },
+      "contentName": "meta.embedded.LANGUAGE",
+      "end": "(\\1)(?:[\\t ]*$)",
+      "endCaptures": {
+        "1": {
+          "name": "string.other.end.code.fenced.mdx"
+        }
+      },
+      "name": "markup.code.LANGUAGE.mdx",
       "patterns": [
         {
-          // This adds supports for code blocks using the ```LANGUAGE delimiter.
-          "begin": "(?:^|\\G)[\\t ]*(`{3,})(?:[\\t ]*((?i:(?:.*\\.)?LANGUAGE))(?:[\\t ]+((?:[^\\n\\r`])+))?)(?:[\\t ]*$)",
-          "beginCaptures": {
-            "1": {
-              "name": "string.other.begin.code.fenced.mdx"
-            },
-            "2": {
-              "name": "entity.name.function.mdx"
-            }
-          },
-          "contentName": "meta.embedded.LANGUAGE",
-          "end": "(\\1)(?:[\\t ]*$)",
-          "endCaptures": {
-            "1": {
-              "name": "string.other.end.code.fenced.mdx"
-            }
-          },
-          "name": "markup.code.LANGUAGE.mdx",
-          "patterns": [
-            {
-              "include": "source.LANGUAGE"
-            }
-          ]
+          "include": "source.LANGUAGE"
+        }
+      ]
+    },
+    {
+      "begin": "(?:^|\\G)[\\t ]*(~{3,})(?:[\\t ]*((?i:(?:.*\\.)?LANGUAGE))(?:[\\t ]+((?:[^\\n\\r])+))?)(?:[\\t ]*$)",
+      "beginCaptures": {
+        "1": {
+          "name": "string.other.begin.code.fenced.mdx"
         },
+        "2": {
+          "name": "entity.name.function.mdx"
+        }
+      },
+      "contentName": "meta.embedded.LANGUAGE",
+      "end": "(\\1)(?:[\\t ]*$)",
+      "endCaptures": {
+        "1": {
+          "name": "string.other.end.code.fenced.mdx"
+        }
+      },
+      "name": "markup.code.LANGUAGE.mdx",
+      "patterns": [
         {
-          // This adds support for code blocks using the ~~~LANGUAGE delimiter.
-          "begin": "(?:^|\\G)[\\t ]*(~{3,})(?:[\\t ]*((?i:(?:.*\\.)?LANGUAGE))(?:[\\t ]+((?:[^\\n\\r])+))?)(?:[\\t ]*$)",
-          "beginCaptures": {
-            "1": {
-              "name": "string.other.begin.code.fenced.mdx"
-            },
-            "2": {
-              "name": "entity.name.function.mdx"
-            }
-          },
-          "contentName": "meta.embedded.LANGUAGE",
-          "end": "(\\1)(?:[\\t ]*$)",
-          "endCaptures": {
-            "1": {
-              "name": "string.other.end.code.fenced.mdx"
-            }
-          },
-          "name": "markup.code.LANGUAGE.mdx",
-          "patterns": [
-            {
-              "include": "source.LANGUAGE"
-            }
-          ]
+          "include": "source.LANGUAGE"
         }
       ]
     }
-  }
+  ]
 }
-````
+```
 
 In `package.json`, add the following section.
 Replace `LANGUAGE` with your actual language and remove comments.

--- a/packages/vscode-mdx/README.md
+++ b/packages/vscode-mdx/README.md
@@ -17,6 +17,7 @@
 * [TypeScript](#typescript)
 * [Plugins](#plugins)
 * [Syntax highlighting](#syntax-highlighting)
+  * [Custom Languages in Code Blocks](#custom-languages-in-code-blocks)
 * [ESLint](#eslint)
 * [Auto-close tags](#auto-close-tags)
 * [Sponsor](#sponsor)
@@ -59,6 +60,113 @@ repository readme.
 
 Syntax highlighting for MDX is based on the
 [MDX TextMate grammar](https://github.com/wooorm/markdown-tm-language).
+
+### Custom Languages in Code Blocks
+
+MDX for Visual Studio Code supports syntax highlighting for a number of
+well-known languages in code blocks.
+However, it’s impossible to support all languages within the MDX extension.
+Instead, if an extensions adds support for a language, it can add support for
+MDX code blocks.
+
+To support MDX code blocks in your Visual Studio Code extension, use the
+following template.
+Replace `LANGUAGE` with your actual language and remove comments.
+Save the file to `syntaxes/mdx.LANGUAGE.tmLanguage.json`.
+
+````jsonc
+{
+  "fileTypes": [],
+  // This can be something else.
+  "scopeName": "mdx.LANGUAGE.codeblock",
+  "injectionSelector": "L:source.mdx",
+  "patterns": [
+    {
+      // This references the repository key below.
+      "include": "#LANGUAGE-code-block"
+    }
+  ],
+  "repository": {
+    "LANGUAGE-code-block": {
+      "patterns": [
+        {
+          // This adds supports for code blocks using the ```LANGUAGE delimiter.
+          "begin": "(?:^|\\G)[\\t ]*(`{3,})(?:[\\t ]*((?i:(?:.*\\.)?LANGUAGE))(?:[\\t ]+((?:[^\\n\\r`])+))?)(?:[\\t ]*$)",
+          "beginCaptures": {
+            "1": {
+              "name": "string.other.begin.code.fenced.mdx"
+            },
+            "2": {
+              "name": "entity.name.function.mdx"
+            }
+          },
+          "contentName": "meta.embedded.LANGUAGE",
+          "end": "(\\1)(?:[\\t ]*$)",
+          "endCaptures": {
+            "1": {
+              "name": "string.other.end.code.fenced.mdx"
+            }
+          },
+          "name": "markup.code.LANGUAGE.mdx",
+          "patterns": [
+            {
+              "include": "source.LANGUAGE"
+            }
+          ]
+        },
+        {
+          // This adds support for code blocks using the ~~~LANGUAGE delimiter.
+          "begin": "(?:^|\\G)[\\t ]*(~{3,})(?:[\\t ]*((?i:(?:.*\\.)?LANGUAGE))(?:[\\t ]+((?:[^\\n\\r])+))?)(?:[\\t ]*$)",
+          "beginCaptures": {
+            "1": {
+              "name": "string.other.begin.code.fenced.mdx"
+            },
+            "2": {
+              "name": "entity.name.function.mdx"
+            }
+          },
+          "contentName": "meta.embedded.LANGUAGE",
+          "end": "(\\1)(?:[\\t ]*$)",
+          "endCaptures": {
+            "1": {
+              "name": "string.other.end.code.fenced.mdx"
+            }
+          },
+          "name": "markup.code.LANGUAGE.mdx",
+          "patterns": [
+            {
+              "include": "source.LANGUAGE"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+````
+
+In `package.json`, add the following section.
+Replace `LANGUAGE` with your actual language and remove comments.
+
+```jsonc
+{
+  "contributes": {
+    "grammars": [
+      {
+        // This must match the scopeName in the tmLanguage file.
+        "scopeName": "mdx.LANGUAGE.codeblock",
+        "path": "./syntaxes/mdx.LANGUAGE.tmLanguage.json",
+        "injectTo": [
+          "source.mdx"
+        ],
+        "embeddedLanguages": {
+          "source.LANGUAGE": "LANGUAGE",
+        }
+      }
+    ]
+  }
+}
+```
 
 ## ESLint
 


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

MDX syntax highlighting can’t possibly support all past, present, and future languages in code blocks. Extensions can inject their own syntax highlighting.

This documentation helps extension authors to support their own language in MDX code blocks.

<!--do not edit: pr-->
