### PR TITLE
Use an asterisk to toggle emphasis

### DIFF
--- a/.changeset/empty-donkeys-notice.md
+++ b/.changeset/empty-donkeys-notice.md
@@ -1,0 +1,7 @@
+---
+'@mdx-js/language-service': patch
+'@mdx-js/language-server': patch
+'vscode-mdx': patch
+---
+
+Use an asterisk to toggle emphasis

--- a/packages/language-server/test/syntax-toggle.test.js
+++ b/packages/language-server/test/syntax-toggle.test.js
@@ -80,14 +80,14 @@ test('emphasis', async () => {
       changes: {
         'memory://1': [
           {
-            newText: '_',
+            newText: '*',
             range: {
               end: {character: 0, line: 0},
               start: {character: 0, line: 0}
             }
           },
           {
-            newText: '_',
+            newText: '*',
             range: {
               end: {character: 5, line: 0},
               start: {character: 5, line: 0}

--- a/packages/language-service/lib/service-plugin.js
+++ b/packages/language-service/lib/service-plugin.js
@@ -94,7 +94,7 @@ export function createMdxServicePlugin(options) {
                 context,
                 options,
                 'emphasis',
-                '_',
+                '*',
                 args[0],
                 args[1]
               )


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This matches `remark-stringify` defaults.

<!--do not edit: pr-->
