### PR TITLE
Drop support for Node.js 18

### DIFF
--- a/.changeset/legal-crews-visit.md
+++ b/.changeset/legal-crews-visit.md
@@ -1,0 +1,7 @@
+---
+'@mdx-js/typescript-plugin': minor
+'@mdx-js/language-service': minor
+'@mdx-js/language-server': minor
+---
+
+Remove support for Node.js 18

--- a/packages/language-server/README.md
+++ b/packages/language-server/README.md
@@ -217,10 +217,7 @@ Use [`unifiedjs.vscode-mdx`][vscode-mdx] to use the MDX language server with
 
 ## Compatibility
 
-Projects maintained by the unified collective are compatible with all maintained
-versions of Node.js.
-As of now, that is Node.js and 16.0+.
-Our projects sometimes work with older versions, but this is not guaranteed.
+This project is compatible Node.js 20.19+.
 
 This project uses [`vscode-languageserver`][vscode-languageserver] 9, which
 implements language server protocol 3.17.4.

--- a/packages/language-service/README.md
+++ b/packages/language-service/README.md
@@ -154,10 +154,7 @@ configuration.
 
 ## Compatibility
 
-Projects maintained by the unified collective are compatible with all maintained
-versions of Node.js.
-As of now, that is Node.js and 16.0+.
-Our projects sometimes work with older versions, but this is not guaranteed.
+This project is compatible Node.js 20.19+.
 
 ## Types
 

--- a/packages/typescript-plugin/README.md
+++ b/packages/typescript-plugin/README.md
@@ -88,10 +88,7 @@ This is not intended for programmatic use.
 
 ## Compatibility
 
-Projects maintained by the unified collective are compatible with all maintained
-versions of Node.js.
-As of now, that is Node.js and 16.0+.
-Our projects sometimes work with older versions, but this is not guaranteed.
+This project is compatible Node.js 20.19+.
 
 ## Security
 

--- a/packages/typescript-plugin/lib/index.cjs
+++ b/packages/typescript-plugin/lib/index.cjs
@@ -2,30 +2,25 @@
 
 /**
  * @import {TsConfigSourceFile} from 'typescript'
- * @import {Plugin} from 'unified' with {'resolution-mode': 'import'}
+ * @import {Plugin} from 'unified'
  */
 
 const {pathToFileURL} = require('node:url')
 const {
+  createMdxLanguagePlugin,
+  resolveRemarkPlugins
+} = require('@mdx-js/language-service')
+const {
   createAsyncLanguageServicePlugin
 } = require('@volar/typescript/lib/quickstart/createAsyncLanguageServicePlugin.js')
+const {loadPlugin} = require('load-plugin')
+const {default: remarkFrontmatter} = require('remark-frontmatter')
+const {default: remarkGfm} = require('remark-gfm')
 
 const plugin = createAsyncLanguageServicePlugin(
   ['.mdx'],
   2 /* JSX */,
   async (ts, info) => {
-    const [
-      {createMdxLanguagePlugin, resolveRemarkPlugins},
-      {loadPlugin},
-      {default: remarkFrontmatter},
-      {default: remarkGfm}
-    ] = await Promise.all([
-      import('@mdx-js/language-service'),
-      import('load-plugin'),
-      import('remark-frontmatter'),
-      import('remark-gfm')
-    ])
-
     if (info.project.projectKind !== ts.server.ProjectKind.Configured) {
       return {
         languagePlugins: [

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,7 +5,7 @@
     "composite": true,
     "declarationMap": true,
     "lib": ["es2022"],
-    "module": "node16",
+    "module": "nodenext",
     "moduleDetection": "force",
     "strict": true,
     "stripInternal": true,


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

The asynchronous TypeScript plugin keeps causing issues. The goal is to move away from that and make it synchronous. Node.js 20.19 adds support for `require(esm)`, which is a great first step for our use case.

VSCode currently ships with Node.js 20.18. However, this is still fine, as dependencies are bundled in the VSCode extension.

<!--do not edit: pr-->
