### PR TITLE
Filter diagnostics if only MDX files are found

### DIFF
--- a/.changeset/flat-bottles-carry.md
+++ b/.changeset/flat-bottles-carry.md
@@ -1,0 +1,6 @@
+---
+'@mdx-js/typescript-plugin': patch
+'vscode-mdx': patch
+---
+
+Fix `tsconfig.json` diagnostics if only MDX inputs are found

--- a/packages/typescript-plugin/lib/index.cjs
+++ b/packages/typescript-plugin/lib/index.cjs
@@ -16,6 +16,23 @@ const {default: remarkFrontmatter} = require('remark-frontmatter')
 const {default: remarkGfm} = require('remark-gfm')
 
 const plugin = createLanguageServicePlugin((ts, info) => {
+  const {getAllProjectErrors} = info.project
+
+  // Filter out the message “No inputs were found in config file …” if the
+  // project contains MDX files.
+  info.project.getAllProjectErrors = () => {
+    const diagnostics = getAllProjectErrors.call(info.project)
+    const fileNames = info.project.getFileNames(true, true)
+
+    const hasMdx = fileNames.some((fileName) => fileName.endsWith('.mdx'))
+
+    if (hasMdx) {
+      diagnostics.filter((diagnostic) => diagnostic.code !== 18003)
+    }
+
+    return diagnostics
+  }
+
   if (info.project.projectKind !== ts.server.ProjectKind.Configured) {
     return {
       languagePlugins: [


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

If a TypeScript project doesn’t include any files, this is reported on `tsconfig.json`. However, it’s useful to have a `tsconfig.json` file to configure TypeScript inside MDX. This diagnostic is now filtered if there are MDX files in the project.

<!--do not edit: pr-->
