### PR TITLE
Fix resolving a tsconfig directory to a file path

### DIFF
--- a/packages/language-server/lib/index.js
+++ b/packages/language-server/lib/index.js
@@ -52,9 +52,17 @@ connection.onInitialize(async (parameters) => {
     createTypeScriptProject(
       typescript,
       diagnosticMessages,
-      ({configFileName}) => ({
-        languagePlugins: getLanguagePlugins(configFileName)
-      })
+      ({configFileName}) => {
+        // Workaround for https://github.com/volarjs/volar.js/issues/283
+        configFileName &&= typescript.findConfigFile(
+          configFileName,
+          typescript.sys.fileExists
+        )
+
+        return {
+          languagePlugins: getLanguagePlugins(configFileName)
+        }
+      }
     ),
     getLanguageServicePlugins()
   )


### PR DESCRIPTION


<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [ ] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [ ] I made sure the docs are up to date
* [ ] I included tests (or that’s not needed)

### Description of changes

When a project is configured with its tsconfig pointing to a directory rather than a file, it needs to be resolved to a file before trying to read the contents of the file.

Fixes https://github.com/mdx-js/mdx-analyzer/issues/481.

I've raised this as an upstream issue too via
https://github.com/volarjs/volar.js/issues/283.

<!--do not edit: pr-->
